### PR TITLE
utf8 characters in code require the 'utf8' pragma

### DIFF
--- a/lib/Acme/CPANAuthors/Korean.pm
+++ b/lib/Acme/CPANAuthors/Korean.pm
@@ -3,6 +3,7 @@ package Acme::CPANAuthors::Korean;
 use strict;
 use warnings;
 our $VERSION = '0.12';
+use utf8;
 
 use Acme::CPANAuthors::Register (
     AANOAA   => "Hyungsuk Hong",


### PR DESCRIPTION
I got this report, caused by some other CPANAuthors module(s) with undeclared wide characters -- http://www.cpantesters.org/cpan/report/f3350cfa-ef0b-11e2-90ca-df1f445abc7e
